### PR TITLE
친구 조회 기능 로직 수정

### DIFF
--- a/src/main/java/com/sparta/iinewsfeedproject/entity/User.java
+++ b/src/main/java/com/sparta/iinewsfeedproject/entity/User.java
@@ -50,8 +50,4 @@ public class User extends Timestamped  {
     public void savePassword(String password) {
         this.password = password;
     }
-
-    public void setName(String newName) {
-        this.name = name;
-    }
 }

--- a/src/main/java/com/sparta/iinewsfeedproject/entity/User.java
+++ b/src/main/java/com/sparta/iinewsfeedproject/entity/User.java
@@ -24,6 +24,7 @@ public class User extends Timestamped  {
     @OneToMany(mappedBy = "user")
     private List<Post> post = new ArrayList<>();
 
+    @Setter
     @Column(name="name")
     @Comment(value = "이름")
     private String name;

--- a/src/main/java/com/sparta/iinewsfeedproject/repository/FriendRepository.java
+++ b/src/main/java/com/sparta/iinewsfeedproject/repository/FriendRepository.java
@@ -15,8 +15,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     // 특정 친구 관계 삭제
     void deleteByFromUserIdAndToUserId(Long fromUserId, Long userId);
 
-    // 특정 사용자의 친구 목록 중 수락된 친구만 조회
-    List<Friend> findByFromUserIdAndStatus(Long fromUserId, String status);
+    // 특정 사용자가 fromUserId 또는 toUserId로 있는 친구 관계 조회
+    List<Friend> findByFromUserIdAndStatusOrToUserIdAndStatus(Long fromUserId, String fromStatus, Long toUserId, String toStatus);
 
     // 요청받은 유저가 fromUserId에 존재할 경우 삭제
     void deleteByFromUserId(Long fromUserId);


### PR DESCRIPTION
기존에 friend table에서 조회 기능을 수행할 때 from user id를 기준으로 친구 관계를 검색했음.
➡️ to user id로 등록된 친구는 검색 되지 않는 문제 발생
해결 : 조회시 from user id와 to user id 모두에서 검색하여 친구 목록 반환으로 수정